### PR TITLE
Improve tauri updater from github latest tag

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -61,7 +61,7 @@
     "updater": {
       "active": true,
       "endpoints": [
-        "https://github.com/TristanPouliquen/selection-poste-enm/main/latest.json"
+        "https://github.com/TristanPouliquen/selection-poste-enm/releases/latest/download/latest.json"
       ],
       "dialog": true,
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDUxODE0QkI0QTZFRTQyNDcKUldSSFF1Nm10RXVCVWZFVW9EMkl4MEl4NW82eXRWRG1VV2dJWExCU0tEQ3FFL1A0V1c5L0JUaHkK"


### PR DESCRIPTION
Using the correct URL from the repo, plus the latest download tag, will let tauri-app autoupdater function using the GitHub releases and the latest tag.  
  
Needs to be marked as the latest and released to work.  
  
Testing tags can get done with 
```bash
curl -OJL https://github.com/TristanPouliquen/selection-poste-enm/releases/latest/download/latest.json
```
older tags and also be test with
```bash
curl -OJL https://github.com/TristanPouliquen/selection-poste-enm/releases/download/v1.1.1/latest.json
```
```curl``` will try and download ```latest.json``` file into the current folder, best to make sure that ```latest.json``` does not already exist locally, else no download is done during testing.